### PR TITLE
fixes API breaking change of Node 4/6 compatibility

### DIFF
--- a/lib/utility/UserRc.js
+++ b/lib/utility/UserRc.js
@@ -58,7 +58,8 @@ var UserRc = (function () {
         var _this = this;
         return rxjs_1.Observable.create(function (observer) {
             /* tslint:disable:no-bitwise */
-            return fs.access(_this._rcHome, fs.constants.R_OK | fs.constants.W_OK, function (err) {
+            var fsConstants = fs.constants || fs; // node 4 (LTS) compatibility
+            return fs.access(_this._rcHome, fsConstants.R_OK | fsConstants.W_OK, function (err) {
                 /* tslint:enable:no-bitwise */
                 if (err) {
                     observer.error(err);

--- a/src/utility/UserRc.ts
+++ b/src/utility/UserRc.ts
@@ -70,7 +70,8 @@ export class UserRc {
   streamRc(): Observable<UserRc> {
     return Observable.create((observer: any) => {
       /* tslint:disable:no-bitwise */
-      return fs.access(this._rcHome, fs.constants.R_OK | fs.constants.W_OK, (err) => {
+	  const fsConstants = fs.constants || <typeof fs.constants><any>fs; // node 4 (LTS) compatibility
+      return fs.access(this._rcHome, fsConstants.R_OK | fsConstants.W_OK, (err) => {
       /* tslint:enable:no-bitwise */
         if (err) {
           observer.error(err);


### PR DESCRIPTION
FS.constants was introduced in node 6, for node 4 LTS (long term support) the values are in FS directly.