### PR TITLE
MDM-11960: connection / generate code (rename)

### DIFF
--- a/src/commands/Connection.ts
+++ b/src/commands/Connection.ts
@@ -72,7 +72,7 @@ export class Connection extends Command {
       }
     },
     createInterfaces: {
-      label: this.i18n.CONNECTION_RENDER_METAMODEL_LABEL
+      label: this.i18n.CONNECTION_GENERATE_CODE
     },
     list: {
       when: () => {

--- a/src/utility/Translation.ts
+++ b/src/utility/Translation.ts
@@ -74,7 +74,7 @@ export class Translation {
   static CONNECTION_ADD_CONNECTION_BEFORE = `Please add first a connection for this feature.`;
   static CONNECTION_ADD_SERVER_BEFORE = `Please add first a Server to create a Connection.`;
   static CONNECTION_LIST_TABLEHEADERS = ['Connection Name', 'Description'];
-  static CONNECTION_RENDER_METAMODEL_LABEL = 'generate code';
+  static CONNECTION_GENERATE_CODE = 'generate code';
   /**
    * Logger Command
    */


### PR DESCRIPTION
Change CONNECTION_RENDER_METAMODEL_LABEL to CONNECTION_GENERATE_CODE for readability