### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/gii/templates/new/RelutionHjson.js
+++ b/lib/gii/templates/new/RelutionHjson.js
@@ -1,5 +1,5 @@
 "use strict";
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var FileApi_1 = require('./../../../utility/FileApi');
 var Translation_1 = require('./../../../utility/Translation');
 var html = require('common-tags').html;

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "lodash": "^4.14.2",
     "mkdirp": "^0.5.1",
     "node": "0.0.0",
-    "node-uuid": "^1.4.7",
     "nopt": "^3.0.6",
     "npm": "^3.10.7",
     "pascal-case": "^2.0.0",
@@ -108,6 +107,7 @@
     "to-iso-string": "0.0.2",
     "typescript-formatter": "^3.1.0",
     "username": "^2.1.0",
+    "uuid": "^3.0.0",
     "websql": "^0.4.4"
   }
 }

--- a/src/gii/templates/new/RelutionHjson.ts
+++ b/src/gii/templates/new/RelutionHjson.ts
@@ -1,4 +1,4 @@
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 import {FileApi} from './../../../utility/FileApi';
 import {Translation} from './../../../utility/Translation';
 import {TemplateInterface} from './../../TemplateInterface';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.